### PR TITLE
[PATCH] fix route -6 output and check for tty

### DIFF
--- a/lib/inet6_gr.c
+++ b/lib/inet6_gr.c
@@ -78,9 +78,15 @@ int rprint_fib6(int ext, int numeric)
     else
     	printf(_("Kernel IPv6 routing table\n"));
 
-    printf(_("Destination                    "
-	     "Next Hop                   "
-	     "Flag Met Ref Use If\n"));
+    if (isatty(fileno(stdout))) {
+        printf(_("Destination                    "
+                 "Next Hop                   "
+	             "Flag Met Ref Use If\n"));
+    } else {
+        printf(_("Destination                                  "
+                 "Next Hop                                     "
+	             "Flag Met Ref Use If\n"));
+    }
 
     while (fgets(buff, 1023, fp)) {
 	num = sscanf(buff, "%4s%4s%4s%4s%4s%4s%4s%4s %02x %4s%4s%4s%4s%4s%4s%4s%4s %02x %4s%4s%4s%4s%4s%4s%4s%4s %08x %08x %08x %08x %15s\n",
@@ -149,8 +155,14 @@ int rprint_fib6(int ext, int numeric)
 	    strcat(flags, "f");
 
 	/* Print the info. */
-	printf("%-30s %-26s %-4s %-3d %-1d%6d %s\n",
-	       addr6, naddr6, flags, metric, refcnt, use, iface);
+    if (isatty(fileno(stdout))) {
+	    printf("%-30s %-26s %-4s %-3d %-1d%6d %s\n",
+                addr6, naddr6, flags, metric, refcnt, use, iface);
+    } else {
+        printf("%-44s %-44s %-4s %-3d %-1d%6d %s\n",
+                addr6, naddr6, flags, metric, refcnt, use, iface);
+    }
+
     }
 
     (void) fclose(fp);


### PR DESCRIPTION
Signed-off-by: Lehner Florian dev@der-flo.net

hi!

Currently 'route -6' doesn't fit into a line of 80 characters. In addition the length of $addr6 and $naddr6 differs.
This patch checks if the output is printed on TTY or not. If the destination is a TTY nothing changes.

The following gist shows two outputs of 'route -6': https://gist.github.com/florianl/8269072
In the first output you can see, how it looks like at the moment. The following output displays how it could look like using the attached patch.

with kind regards,
Florian
