### PR TITLE
Spell checking for German netstat manpage

### DIFF
--- a/man/de_DE/netstat.8
+++ b/man/de_DE/netstat.8
@@ -68,15 +68,15 @@ netstat \- Anzeige von Netzwerksverbindungen, Routentabellen, Schnittstellenstat
 .PP
 .SH BESCHREIBUNG
 .B Netstat
-zeigt Informationen des Linux Netzwerkssystems an.
+zeigt Informationen des Linux-Netzwerkssystems an.
 .PP
-.B Bitte beachten Sie, dass der Inhalt der deutschen man-page nicht vollst\(:andig ist, im Moment.
+.B Bitte beachten Sie, dass der Inhalt der deutschen man-page derzeit noch nicht vollst\(:andig ist.
 
 .SS "(no option)"
 Ohne Optionen zeigt
 .B netstat
 den Zustand von offenen Sockets an.  Wird keine Adressfamilie angegeben, dann
-werden die offenen Sockets aller konfigurierten Adressfamilien gedruckt.
+werden die offenen Sockets aller konfigurierten Adressfamilien angezeigt.
 Die Option
 .B -e
 gibt zus\(:atzliche Informationen aus (User ID).  Mit der Option
@@ -89,10 +89,10 @@ Adressfamilien aus.  Die Option
 gibt zus\(:atzlich die PID und den Namen des Programms, das den Socket
 ge\(:offnet hat, aus.
 .B -a
-druckt alle Sockets einschlie\(sslich der auf Verbinungen wartenden
-Serversockets aus.  Die Adressfamilie
+zeigt alle Sockets einschlie\(sslich der auf Verbinungen wartenden
+Serversocketsan.  Die Adressfamilie
 .B inet
-zeigt RAW, UDP und TCP Sockets an.
+beinhaltet RAW, UDP und TCP Sockets.
 
 .SS "\-r, \-\-route"
 Die
@@ -103,35 +103,35 @@ aus.
 .B "netstat -er" 
 benutzt das Ausgabeformat von
 .BR route .
-Wegen Details siehe
+F\(:ur Details siehe
 .BR route (8).
 
 .SS "\-i, \-\-interfaces"
 Wird die
 .BR -i ", " --interfaces
 Option verwendet,  so wird eine Tabelle aller Schnittstellen
-ausgedruckt.  Die Ausgabe ist im Format von
+ausgegeben.  Die Ausgabe ist im Format von
 .B "ifconfig -e"
 und wird in
 .BR ifconfig (8)
 beschrieben.
 .B "netstat -ei" 
-druckt eine Tabelle f\(:ur Interfaces wie
+erzeugt eine Tabelle f\(:ur Interfaces wie
 .BR ifconfig .
 Die
 .B -a
-Option schlie\(sst Schnittstellen, die gar nicht konfiguriert sind in die
-Ausgabe ein, d.h. die die
+Option schlie\(sst nicht konfigurierte Schnittstellen in die
+Ausgabe ein (d.h. die das
 .BR U = UP
-Flagge nicht gesetzt haben).
+Flag nicht gesetzt haben).
 
 .SS "\-M, \-\-masquerade"
 
-Eine Liste aller maskierten Sitzungen wird dargestellt.  Der
+Hiermit wird eine Liste aller maskierten Sitzungen erstellt. Der
 .B -e 
-Schalter schlie\(sst zus\(:atzlich Information \(:uber Sequenznummern und
+Schalter schlie\(sst zus\(:atzlich Informationen \(:uber Sequenznummern und
 Deltas, die durch das Umschreiben von FTP-Sitzungen (PORT Kommando) verursacht
-werden.  Maskieren wird dazu verwendet um Maschinen mit inoffiziellen
+werden, ein.  Maskieren wird verwendet, um Maschinen mit inoffiziellen
 Netzwerkssitzungen vor der Au\(ssenwelt zu verstecken.  Dies wird in
 .BR ipfw (4),
 .BR ipfwadm (8)
@@ -141,8 +141,8 @@ beschrieben.
 
 .SS "\-N, \-\-netlink"
 
-Aktuelle Kern unterst\(:utzen die Kommunikation zwischen Kern und Anwendungen
-durch eine Option namens Netlink.  Netlink erm\(:oglicht es Informationen
+Aktuelle Kernel unterst\(:utzen die Kommunikation zwischen Kernel und Anwendungen
+durch eine Option namens Netlink.  Netlink erm\(:oglicht, Informationen
 \(:uber die Erzeugung und das L\(:oschen von Schnittstellen oder Routen von
 .I /dev/route
 (36,0) zu erhalten.
@@ -151,22 +151,22 @@ durch eine Option namens Netlink.  Netlink erm\(:oglicht es Informationen
 .SH OPTIONEN
 .SS "\-v, \-\-verbose"
 macht detailiertere Ausgaben.  Insbesondere wird ausgegeben, welche
-Adressfamilien nicht im Kern konfiguriert sind.
+Adressfamilien nicht im Kernel konfiguriert sind.
 
 .SS "\-n, \-\-numeric"
-gibt numerische Adressen aus, anstelle zu versuchen, den symbolischen
-Rechner, Port oder Benutzernamen auszugeben.
+gibt numerische Adressen anstelle von 
+Rechner-, Port- oder Benutzernamen aus.
 
 .SS "\-p, \-\-programs"
 Zeigt den Prozessnamen und die PID des Eigent\(:umers des Sockets, der
 ausgegeben wird.  Nur der Eigent\(:umer eines Prozess oder
 .B Root
-haben alle die dazu n\(:otigen Privilegien.
+haben alle dazu n\(:otigen Privilegien.
 
 .SS "\-A, \-\-af \fIFamilie\fI"
 benutzt einen alternativen Weg, um Adressfamilien zu setzen.
 .I Familie 
-ist eine von Kommatas abgetrennte Liste von Schl\(:usselworten f\(:ur
+ist eine durch Kommas getrennte Auflistung von Schl\(:usselworten f\(:ur
 Adressfamilien wie
 .BR inet , 
 .BR unix , 
@@ -175,7 +175,7 @@ Adressfamilien wie
 .B netrom 
 und
 .BR ddp .
-Dies hat den gleichen Effekt wie die Langoptionen
+Dies hat den gleichen Effekt wie die Optionen
 .BR \-\-inet ,
 .BR \-\-unix ,
 .BR \-\-ipx ,
@@ -196,7 +196,7 @@ im Sekundenabstand die Ausgabe, bis es abgebrochen wird.
 .SS Aktive Internet-Verbindungen \fR(TCP, UDP, RAW)\fR
 
 .SS "Proto" 
-Das von Socket verwendete Protokoll (TCP, UDP, RAW).
+Das vom Socket verwendete Protokoll (TCP, UDP, RAW).
 
 .SS "Recv-Q"
 Die Anzahl von Bytes, die noch nicht von der Anwendung vom Socket abgeholt
@@ -210,13 +210,13 @@ Die lokale Adresse (lokaler Rechnername) und Portnummer des Sockets.  Au\(sser
 bei Verwendung der
 .B -n
 Option wird die Socketadresse nach dem kanonischen Rechnernamen und die
-Portnummer in den zugeh\(:origen Dienstenamen aufgel\(sst.
+Portnummer in den zugeh\(:origen Dienstenamen aufgel\(:ost.
 
 .SS "Gegenadresse"
 Die Adresse und Portnummer der Gegenseite des Sockets.  Wie bei lokalen
-Adressen schaltet der
+Adressen werden mit
 .B -n
-Schalter die Umwandlung von Rechneradresse und Portnummer ab.
+Rechneradresse und Portnummer numerisch angezeigt.
 
 .SS "State"
 Der Zustand des Sockets.  Da RAW-Sockets keinen und UDP-Sockets
@@ -225,11 +225,11 @@ Normalerweise ist sie einer von mehreren Werten:
 .TP
 .I
 VERBUNDEN
-The socket has an established connection.
+Dieser Socket hat eine Verbindung hergestellt.
 .TP
 .I
 SYN_SENT
-Es wird versucht auf dem Socket eine Verbindung aufzubauen.
+Es wird versucht, auf dem Socket eine Verbindung aufzubauen.
 .TP
 .I
 SYN_RECV
@@ -246,7 +246,7 @@ von der Gegenseite ebenfalls geschlo\(ssen wird.
 .TP
 .I
 TIME_WAIT
-Der Socket ist nach dem Schlie\(ssen im Wartezustand um Pakete handzuhaben,
+Der Socket ist nach dem Schlie\(ssen im Wartezustand, um Pakete entgegenzunehmen,
 die sich eventuell noch im Netzwerk befinden.
 .TP
 .I
@@ -266,15 +266,13 @@ die Best\(:atigung wird abgewartet.
 .I
 LISTEN
 Der Socket wartet auf eingehende Verbindungen.  Diese Sockets werden nur
-angezeit, wenn die
-The socket is listening for incoming connections. Those sockets are only
-displayed if the
+angezeigt, wenn die
 .BR -a , --listening
-Option gegeben wird.
+Option gew\(:ahlt wird.
 .TP
 .I
 CLOSING
-Beide Sockets sind geschlo\(ssen es wurden aber noch nicht alle Daten
+Beide Sockets sind geschlo\(ssen, es wurden aber noch nicht alle Daten
 geschickt.
 .TP
 .I
@@ -294,19 +292,19 @@ Privilegien ben\(:otigt um die n\(:otigen Daten zu erhalten.  F\(:ur IPX
 Sockets sind diese Daten nicht verf\(:ugbar.
 
 .SS "Timer"
-(Dies mu\(ss noch geschrieben werden)
+(dies mu\(ss noch geschrieben werden)
 
 .PP
-.SS Aktive Sockets in der UNIX Dom\(:ane
+.SS aktive Sockets in der UNIX Dom\(:ane
 
 .SS "Proto" 
-Das Protokoll (in der Regel unix), das vom Socket verwendet wird.
+das Protokoll (in der Regel unix), welches vom Socket verwendet wird
 
 .SS "RefZ\(:ah"
-Der Referenzz\(:ahler, d.h. die Zahl der Prozesse, die diesen Socket benutzen.
+der Referenzz\(:ahler, d.h. die Zahl der Prozesse, die diesen Socket benutzen
 
 .SS "Flaggen"
-Die Flaggen, die angezeigt werden sind SO_ACCEPTON (angezeigt als
+die Flags, die angezeigt werden sind SO_ACCEPTON (angezeigt als
 .BR ACC ),
 SO_WAITDATA 
 .RB ( W )
@@ -314,7 +312,7 @@ oder SO_NOSPACE
 .RB ( N ). 
 SO_ACCECPTON 
 wird auf unverbundenen Sockets verwendet, wenn die zugeh\(:origen Sockets
-auf Verbindungsanfragen warten.  Die anderen Flaggen sind normalerweise nicht
+auf Verbindungsanfragen warten.  Die anderen Flags sind normalerweise nicht
 von Interesse.
 
 .SS "Typ"
@@ -359,7 +357,7 @@ Der Socket ist unbenutzt
 .TP
 .I
 H\(:Ort
-Der Socket lauscht nach Verbindungsanfragen.  Diese Sockets werden nur
+Der Socket lauscht auf Verbindungsanfragen.  Diese Sockets werden nur
 angezeigt, wenn die
 .BR -a , --listening
 Option gesetzt ist.
@@ -382,7 +380,7 @@ Der Socket hat keine Verbundung zu einem anderen Socket.
 .TP
 .I
 UNKNOWN
-Ein Socket sollte niemals in diesem Zustand sein.
+Unbekannt - ein Socket sollte niemals in diesem Zustand sein.
 
 .SS "PID/Programmname"
 Prozess-ID und Programmname des Programs, das diesen Socket h\(:alt.  Details
@@ -390,25 +388,24 @@ siehe oben unter
 .BR "Aktive Internetverbindungen" .
 
 .SS "Pfad"
-This displays the path name as which the corresponding processes attached
-to the socket.
+Zeigt den Pfad des Prozesses an, welcher den Socket h\(:alt.
 
 .PP
 .SS Aktive IPX-Sockets
 
-(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat geschrieben
+(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat, geschrieben
 werden.)
 
 .PP
-.SS Aktive NET/ROM-Verdingungen
+.SS Aktive NET/ROM-Verbindungen
 
-(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat geschrieben
+(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat, geschrieben
 werden.)
 
 .PP
 .SS Aktive AX.25-Verbindungen
 
-(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat geschrieben
+(Dieser Abschnitt sollte von jemandem, der davon Ahnung hat, geschrieben
 werden.)
 
 .PP
@@ -459,10 +456,10 @@ Befehl explizite Regeln zugef\(:ugt werden.
 -- Informationen zu Kernelrouten
 
 .I /proc/net/ax25_route
--- Kernelinformationen zum AX25-Routen
+-- Kernelinformationen zu AX25-Routen
 
 .I /proc/net/ipx_route
--- Kernelinformationen zum IPX-Routen
+-- Kernelinformationen zu IPX-Routen
 
 .I /proc/net/nr_nodes
 -- Kernelliste der NET/ROM-Knoten
@@ -471,7 +468,7 @@ Befehl explizite Regeln zugef\(:ugt werden.
 -- Kernelliste der NET/ROM-Nachbarn
 
 .I /proc/net/ip_masquerade
--- Liste der maskierten Verbindungen.
+-- Liste der maskierten Verbindungen
 
 .fi
 
@@ -483,13 +480,13 @@ Befehl explizite Regeln zugef\(:ugt werden.
 
 .PP
 .SH PROBLEME
-\(:Andert sich der Zustand des Sockets w\(:ahrend er gerade angezeigt wird,
-so kann unsinnige Information ausgegeben werden.  Dies ist jedoch
+\(:Andert sich der Zustand des Sockets, w\(:ahrend er gerade angezeigt wird,
+so k\(:onnen unsinnige Informationen ausgegeben werden.  Dies ist jedoch
 unwahrscheinlich.
 .br
-Die
+Der beschriebene Parameter
 .B netstat -i
-die beschrieben wird sollte nach einigem S\(:aubern der BETA-Version des
+sollte nach einigem S\(:aubern der BETA-Version des
 Codes des Net-Tools Packets funktionieren.
 
 .PP


### PR DESCRIPTION
I corrected a bunch of typos and spelling mistakes in the German netstat manpage. Since this is my first pull request ever, I hope this commit is useable. Please let me know, if anything needs to be adapted or changed.