### PR TITLE
Support for custom procfs path using ENV variable

### DIFF
--- a/netstat.c
+++ b/netstat.c
@@ -272,7 +272,7 @@ static char prg_cache_loaded = 0;
 #define PATH_PROC	   "/proc"
 #define PATH_FD_SUFF	"fd"
 #define PATH_FD_SUFFl       strlen(PATH_FD_SUFF)
-#define PATH_PROC_X_FD      PATH_PROC "/%s/" PATH_FD_SUFF
+#define PATH_PROC_X_FD      "%s" "/%s/" PATH_FD_SUFF
 #define PATH_CMDLINE	"cmdline"
 #define PATH_CMDLINEl       strlen(PATH_CMDLINE)
 
@@ -419,7 +419,7 @@ static void prg_cache_load(void)
 		break;
 	if (*cs)
 	    continue;
-	procfdlen = snprintf(line,sizeof(line),PATH_PROC_X_FD,direproc->d_name);
+	procfdlen = snprintf(line,sizeof(line),PATH_PROC_X_FD,path_proc,direproc->d_name);
 	if (procfdlen <= 0 || procfdlen >= sizeof(line) - 5)
 	    continue;
 	errno = 0;

--- a/netstat.c
+++ b/netstat.c
@@ -269,7 +269,7 @@ static char prg_cache_loaded = 0;
 #define LINE_MAX 4096
 #endif
 
-#define PATH_PROC	   "/proc"
+#define DEFAULT_PATH_PROC	   "/proc"
 #define PATH_FD_SUFF	"fd"
 #define PATH_FD_SUFFl       strlen(PATH_FD_SUFF)
 #define PATH_PROC_X_FD      "%s" "/%s/" PATH_FD_SUFF
@@ -2073,7 +2073,7 @@ int main
 
     path_proc = getenv("PATH_PROC");
     if ( path_proc == NULL ) {
-        path_proc = PATH_PROC;
+        path_proc = DEFAULT_PATH_PROC;
     }
 
     afname[0] = '\0';

--- a/netstat.c
+++ b/netstat.c
@@ -169,6 +169,7 @@ int flag_ver = 0;
 int flag_l2cap = 0;
 int flag_rfcomm = 0;
 int flag_selinux = 0;
+char *path_proc = NULL;
 
 FILE *procinfo;
 
@@ -411,7 +412,7 @@ static void prg_cache_load(void)
     if (prg_cache_loaded || !flag_prg) return;
     prg_cache_loaded = 1;
     cmdlbuf[sizeof(cmdlbuf) - 1] = '\0';
-    if (!(dirproc=opendir(PATH_PROC))) goto fail;
+    if (!(dirproc=opendir(path_proc))) goto fail;
     while (errno = 0, direproc = readdir(dirproc)) {
 	for (cs = direproc->d_name; *cs; cs++)
 	    if (!isdigit(*cs))
@@ -2069,6 +2070,11 @@ int main
     textdomain("net-tools");
 #endif
     getroute_init();		/* Set up AF routing support */
+
+    path_proc = getenv("PATH_PROC");
+    if ( path_proc == NULL ) {
+        path_proc = PATH_PROC;
+    }
 
     afname[0] = '\0';
     while ((i = getopt_long(argc, argv, "A:CFMacdeghilnNoprsStuUvVWw2fx64?Z", longopts, &lop)) != EOF)


### PR DESCRIPTION
This PR addresses issue https://github.com/ecki/net-tools/issues/12 . 
Setting the environment variable PATH_PROC to the path of the procfs will allow netstat fill in the process/pid data using PATH_PROC value