### PR TITLE
optimizing: 'config.in' macros

### DIFF
--- a/config.in
+++ b/config.in
@@ -47,18 +47,7 @@ bool 'Does your system support GNU gettext?' I18N n
 *
 *             Protocol Families.
 *
-bool 'UNIX protocol family' HAVE_AFUNIX y
-bool 'INET (TCP/IP) protocol family' HAVE_AFINET y
-bool 'INET6 (IPv6) protocol family' HAVE_AFINET6 y
-bool 'Novell IPX/SPX protocol family' HAVE_AFIPX y
-bool 'Appletalk DDP protocol family' HAVE_AFATALK y
-bool 'AX25 (packet radio) protocol family' HAVE_AFAX25 y
-bool 'NET/ROM (packet radio) protocol family' HAVE_AFNETROM y
-bool 'Rose (packet radio) protocol family' HAVE_AFROSE y
-bool 'X.25 (CCITT) protocol family' HAVE_AFX25 y
-bool 'Econet protocol family' HAVE_AFECONET n
 bool 'DECnet protocol family' HAVE_AFDECnet n
-bool 'Ash protocol family' HAVE_AFASH y
 bool 'Bluetooth protocol family' HAVE_AFBLUETOOTH n
 *
 *

--- a/hostname.c
+++ b/hostname.c
@@ -46,7 +46,7 @@
 #include "net-support.h"
 #include "../intl.h"
 
-#if HAVE_AFINET6
+#if AF_INET6
 #include <sys/socket.h> /* for PF_INET6 */
 #include <sys/types.h>  /* for inet_ntop */
 #endif
@@ -133,7 +133,7 @@ static void showhname(const char *hname, int c)
 {
     struct hostent *hp;
     char *p, **alias;
-#if HAVE_AFINET6
+#if AF_INET6
     char addr[INET6_ADDRSTRLEN + 1];
 #else
     char addr[INET_ADDRSTRLEN + 1];
@@ -149,7 +149,7 @@ static void showhname(const char *hname, int c)
     if (opt_v)
 	fprintf(stderr, _("Resolving `%s' ...\n"), hname);
     if (
-#if HAVE_AFINET6
+#if AF_INET6
         !(hp = gethostbyname2(hname, PF_INET6)) &&
 #endif
         !(hp = gethostbyname(hname))) {

--- a/ifconfig.c
+++ b/ifconfig.c
@@ -53,7 +53,7 @@
 #include <linux/if_slip.h>
 #endif
 
-#if HAVE_AFINET6
+#if AF_INET6
 
 #ifndef _LINUX_IN6_H
 /*
@@ -68,9 +68,9 @@ struct in6_ifreq {
 
 #endif
 
-#endif				/* HAVE_AFINET6 */
+#endif				/* AF_INET6 */
 
-#if HAVE_AFIPX
+#if AF_IPX
 #if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1)
 #include <netipx/ipx.h>
 #else
@@ -202,7 +202,7 @@ static void usage(int rc)
 {
     FILE *fp = rc ? stderr : stdout;
     fprintf(fp, _("Usage:\n  ifconfig [-a] [-v] [-s] <interface> [[<AF>] <address>]\n"));
-#if HAVE_AFINET
+#if AF_INET
     fprintf(fp, _("  [add <address>[/<prefixlen>]]\n"));
     fprintf(fp, _("  [del <address>[/<prefixlen>]]\n"));
     fprintf(fp, _("  [[-]broadcast [<address>]]  [[-]pointopoint [<address>]]\n"));
@@ -267,14 +267,14 @@ int main(int argc, char **argv)
     int goterr = 0, didnetmask = 0, neednetmask=0;
     char **spp;
     int fd;
-#if HAVE_AFINET6
+#if AF_INET6
     extern struct aftype inet6_aftype;
     struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&_sa;
     struct in6_ifreq ifr6;
     unsigned long prefix_len;
     char *cp;
 #endif
-#if HAVE_AFINET
+#if AF_INET
     extern struct aftype inet_aftype;
 #endif
 
@@ -726,11 +726,11 @@ int main(int argc, char **argv)
 	    spp++;
 	    continue;
 	}
-#if HAVE_AFINET || HAVE_AFINET6
+#if AF_INET || AF_INET6
 	if (!strcmp(*spp, "add")) {
 	    if (*++spp == NULL)
 		usage(E_OPTERR);
-#if HAVE_AFINET6
+#if AF_INET6
 	    if (strchr(*spp, ':')) {
 		/* INET6 */
 		if ((cp = strchr(*spp, '/'))) {
@@ -777,7 +777,7 @@ int main(int argc, char **argv)
 		continue;
 	    }
 #endif
-#if HAVE_AFINET
+#if AF_INET
 	    { /* ipv4 address a.b.c.d */
 		in_addr_t ip, nm, bc;
 		safe_strncpy(host, *spp, (sizeof host));
@@ -816,13 +816,13 @@ int main(int argc, char **argv)
 	}
 #endif
 
-#if HAVE_AFINET || HAVE_AFINET6
+#if AF_INET || AF_INET6
 	if (!strcmp(*spp, "del")) {
 	    if (*++spp == NULL)
 		usage(E_OPTERR);
 
 #ifdef SIOCDIFADDR
-#if HAVE_AFINET6
+#if AF_INET6
 	    if (strchr(*spp, ':')) {	/* INET6 */
 		if ((cp = strchr(*spp, '/'))) {
 		    prefix_len = atol(cp + 1);
@@ -869,7 +869,7 @@ int main(int argc, char **argv)
 		continue;
 	    }
 #endif
-#if HAVE_AFINET
+#if AF_INET
 	    {
 		/* ipv4 address a.b.c.d */
 		in_addr_t ip, nm, bc;
@@ -911,7 +911,7 @@ int main(int argc, char **argv)
 #endif
 	}
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
 	if (!strcmp(*spp, "tunnel")) {
 	    if (*++spp == NULL)
 		usage(E_OPTERR);
@@ -993,7 +993,7 @@ int main(int argc, char **argv)
 	{
 	    int r = 0;		/* to shut gcc up */
 	    switch (ap->af) {
-#if HAVE_AFINET
+#if AF_INET
 	    case AF_INET:
 		fd = get_socket_for_af(AF_INET);
 		if (fd < 0) {
@@ -1003,7 +1003,7 @@ int main(int argc, char **argv)
 		r = ioctl(fd, SIOCSIFADDR, &ifr);
 		break;
 #endif
-#if HAVE_AFECONET
+#if AF_ECONET
 	    case AF_ECONET:
 		fd = get_socket_for_af(AF_ECONET);
 		if (fd < 0) {

--- a/lib/af.c
+++ b/lib/af.c
@@ -119,37 +119,37 @@ static short sVafinit = 0;
 
 struct aftype * const aftypes[] =
 {
-#if HAVE_AFUNIX
+#if AF_UNIX
     &unix_aftype,
 #endif
-#if HAVE_AFINET
+#if AF_INET
     &inet_aftype,
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
     &inet6_aftype,
 #endif
-#if HAVE_AFAX25
+#if AF_AX25
     &ax25_aftype,
 #endif
-#if HAVE_AFNETROM
+#if AF_NETROM
     &netrom_aftype,
 #endif
-#if HAVE_AFROSE
+#if AF_ROSE
     &rose_aftype,
 #endif
-#if HAVE_AFIPX
+#if AF_IPX
     &ipx_aftype,
 #endif
-#if HAVE_AFATALK
+#if AF_APPLETALK
     &ddp_aftype,
 #endif
-#if HAVE_AFECONET
+#if AF_ECONET
     &ec_aftype,
 #endif
-#if HAVE_AFASH
+#if AF_ASH
     &ash_aftype,
 #endif
-#if HAVE_AFX25
+#if AF_X25
     &x25_aftype,
 #endif
     &unspec_aftype,
@@ -159,37 +159,37 @@ struct aftype * const aftypes[] =
 static void afinit(void)
 {
     unspec_aftype.title = _("UNSPEC");
-#if HAVE_AFUNIX
+#if AF_UNIX
     unix_aftype.title = _("UNIX Domain");
 #endif
-#if HAVE_AFINET
+#if AF_INET
     inet_aftype.title = _("DARPA Internet");
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
     inet6_aftype.title = _("IPv6");
 #endif
-#if HAVE_AFAX25
+#if AF_AX25
     ax25_aftype.title = _("AMPR AX.25");
 #endif
-#if HAVE_AFNETROM
+#if AF_NETROM
     netrom_aftype.title = _("AMPR NET/ROM");
 #endif
-#if HAVE_AFIPX
+#if AF_IPX
     ipx_aftype.title = _("Novell IPX");
 #endif
-#if HAVE_AFATALK
+#if AF_APPLETALK
     ddp_aftype.title = _("Appletalk DDP");
 #endif
-#if HAVE_AFECONET
+#if AF_ECONET
     ec_aftype.title = _("Econet");
 #endif
-#if HAVE_AFX25
+#if AF_X25
     x25_aftype.title = _("CCITT X.25");
 #endif
-#if HAVE_AFROSE
+#if AF_ROSE
     rose_aftype.title = _("AMPR ROSE");
 #endif
-#if HAVE_AFASH
+#if AF_ASH
     ash_aftype.title = _("Ash");
 #endif
     sVafinit = 1;

--- a/lib/ash.c
+++ b/lib/ash.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#if HAVE_HWASH || HAVE_AFASH
+#if HAVE_HWASH || AF_ASH
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -100,7 +100,7 @@ struct hwtype ash_hwtype =
 
 #endif	/* HAVE_HWASH */
 
-#if HAVE_AFASH
+#if AF_ASH
 
 /* Display an Ash socket address. */
 static const char *
@@ -123,6 +123,6 @@ struct aftype ash_aftype =
     "/proc/sys/net/ash"
 };
 
-#endif	/* HAVE_AFASH */
+#endif	/* AF_ASH */
 
-#endif	/* HAVE_AFASH || HAVE_HWASH */
+#endif	/* AF_ASH || HAVE_HWASH */

--- a/lib/ax25.c
+++ b/lib/ax25.c
@@ -20,7 +20,7 @@
  */
 #include "config.h"
 
-#if HAVE_AFAX25 || HAVE_HWAX25
+#if AF_AX25 || HAVE_HWAX25
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>

--- a/lib/ax25_gr.c
+++ b/lib/ax25_gr.c
@@ -16,11 +16,11 @@
  */
 #include "config.h"
 
-#if HAVE_AFAX25
+#include <sys/socket.h>
+#if AF_AX25
 #if 0
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <linux/ax25.h>
 #include <linux/if_arp.h>	/* ARPHRD_AX25 */
 #include <ctype.h>
@@ -62,4 +62,4 @@ int AX25_rprint(int options)
     return 0;
 }
 
-#endif				/* HAVE_AFAX25 */
+#endif				/* AF_AX25 */

--- a/lib/ddp.c
+++ b/lib/ddp.c
@@ -14,10 +14,10 @@
  */
 #include "config.h"
 
-#if HAVE_AFATALK
+#include <sys/socket.h>
+#if AF_APPLETALK
 #include <asm/types.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <linux/atalk.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/ddp_gr.c
+++ b/lib/ddp_gr.c
@@ -17,10 +17,10 @@
 
 #include "config.h"
 
-#if HAVE_AFATALK
+#include <sys/socket.h>
+#if AF_APPLETALK
 #include <asm/types.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <linux/atalk.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/econet.c
+++ b/lib/econet.c
@@ -18,10 +18,11 @@
 
 #include "config.h"
 
-#if HAVE_AFECONET
+#include <sys/socket.h>
+
+#if AF_ECONET
 
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <stdio.h>
 #include <neteconet/ec.h>
 
@@ -83,4 +84,4 @@ struct aftype ec_aftype =
     "/proc/sys/net/econet"
 };
 
-#endif				/* HAVE_AFECONET */
+#endif				/* AF_ECONET */

--- a/lib/getroute.c
+++ b/lib/getroute.c
@@ -51,28 +51,28 @@ extern struct aftype x25_aftype;
 
 void getroute_init(void)
 {
-#if HAVE_AFINET
+#if AF_INET
     inet_aftype.rprint = INET_rprint;
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
     inet6_aftype.rprint = INET6_rprint;
 #endif
-#if HAVE_AFNETROM
+#if AF_NETROM
     netrom_aftype.rprint = NETROM_rprint;
 #endif
-#if HAVE_AFROSE
+#if AF_ROSE
     rose_aftype.rprint = ROSE_rprint;
 #endif
-#if HAVE_AFAX25
+#if AF_AX25
     ax25_aftype.rprint = AX25_rprint;
 #endif
-#if HAVE_AFIPX
+#if AF_IPX
     ipx_aftype.rprint = IPX_rprint;
 #endif
-#if HAVE_AFATALK
+#if AF_APPLETALK
     ddp_aftype.rprint = DDP_rprint;
 #endif
-#if HAVE_AFX25
+#if AF_X25
     x25_aftype.rprint = X25_rprint;
 #endif
 }

--- a/lib/inet.c
+++ b/lib/inet.c
@@ -31,10 +31,10 @@
 /* FIXME.  Split this file into inet4.c for the IPv4 specific parts
    and inet.c for those shared between IPv4 and IPv6.  */
 
-#if HAVE_AFINET || HAVE_AFINET6
+#include <sys/socket.h>
+#if AF_INET || AF_INET6
 #include <netinet/in.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <ctype.h>
@@ -69,7 +69,7 @@ struct service {
 
 static struct service *tcp_name = NULL, *udp_name = NULL, *raw_name = NULL;
 
-#if HAVE_AFINET
+#if AF_INET
 
 static struct addr *INET_nn = NULL;	/* addr-to-name cache           */
 
@@ -362,7 +362,7 @@ struct aftype inet_aftype =
     NULL
 };
 
-#endif				/* HAVE_AFINET */
+#endif				/* AF_INET */
 
 static void add2list(struct service **namebase, struct service *item)
 {
@@ -462,4 +462,4 @@ const char *get_sname(int socknumber, const char *proto, int numeric)
     return (buffer);
 }
 
-#endif				/* HAVE_AFINET || HAVE_AFINET6 */
+#endif				/* AF_INET || AF_INET6 */

--- a/lib/inet6.c
+++ b/lib/inet6.c
@@ -21,10 +21,10 @@
  */
 #include "config.h"
 
-#if HAVE_AFINET6
+#include <sys/socket.h>
+#if AF_INET6
 #include <asm/types.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -190,4 +190,4 @@ struct aftype inet6_aftype =
 };
 
 
-#endif				/* HAVE_AFINET6 */
+#endif				/* AF_INET6 */

--- a/lib/inet6_gr.c
+++ b/lib/inet6_gr.c
@@ -6,11 +6,11 @@
 
 #include "config.h"
 
-#if HAVE_AFINET6
+#include <sys/socket.h>
+#if AF_INET6
 #include <asm/types.h>
 #include <asm/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -284,4 +284,4 @@ int INET6_rprint(int options)
     return (rc);
 }
 
-#endif				/* HAVE_AFINET6 */
+#endif				/* AF_INET6 */

--- a/lib/inet6_sr.c
+++ b/lib/inet6_sr.c
@@ -10,11 +10,11 @@
 
 #include "config.h"
 
-#if HAVE_AFINET6
+#include <sys/socket.h>
+#if AF_INET6
 #include <asm/types.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -195,4 +195,4 @@ int INET6_rinput(int action, int options, char **args)
 
     return (INET6_setroute(action, options, args));
 }
-#endif				/* HAVE_AFINET6 */
+#endif				/* AF_INET6 */

--- a/lib/inet_gr.c
+++ b/lib/inet_gr.c
@@ -10,9 +10,9 @@
 
 #include "config.h"
 
-#if HAVE_AFINET
-#include <sys/types.h>
 #include <sys/socket.h>
+#if AF_INET
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -455,4 +455,4 @@ int INET_rprint(int options)
     return (rc);
 }
 
-#endif				/* HAVE_AFINET */
+#endif				/* AF_INET */

--- a/lib/inet_sr.c
+++ b/lib/inet_sr.c
@@ -10,11 +10,11 @@
 
 #include "config.h"
 
-#if HAVE_AFINET
+#include <sys/socket.h>
+#if AF_INET
 #include <asm/types.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -325,4 +325,4 @@ int INET_rinput(int action, int options, char **args)
 
     return (INET_setroute(action, options, args));
 }
-#endif				/* HAVE_AFINET */
+#endif				/* AF_INET */

--- a/lib/interface.c
+++ b/lib/interface.c
@@ -25,7 +25,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#if HAVE_AFIPX
+#if AF_IPX
 #if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1)
 #include <netipx/ipx.h>
 #else
@@ -33,7 +33,7 @@
 #endif
 #endif
 
-#if HAVE_AFECONET
+#if AF_ECONET
 #include <neteconet/ec.h>
 #endif
 
@@ -400,7 +400,7 @@ int if_readlist(void)
 
 /* Support for fetching an IPX address */
 
-#if HAVE_AFIPX
+#if AF_IPX
 static int ipx_getaddr(int sock, int ft, struct ifreq *ifr)
 {
     ((struct sockaddr_ipx *) &ifr->ifr_addr)->sipx_type = ft;
@@ -477,7 +477,7 @@ int if_fetch(struct interface *ife)
     ife->tx_queue_len = -1;	/* unknown value */
 #endif
 
-#if HAVE_AFINET
+#if AF_INET
     /* IPv4 address? */
     fd = get_socket_for_af(AF_INET);
     if (fd >= 0) {
@@ -508,7 +508,7 @@ int if_fetch(struct interface *ife)
     }
 #endif
 
-#if HAVE_AFATALK
+#if AF_APPLETALK
     /* DDP address maybe ? */
     fd = get_socket_for_af(AF_APPLETALK);
     if (fd >= 0) {
@@ -520,7 +520,7 @@ int if_fetch(struct interface *ife)
     }
 #endif
 
-#if HAVE_AFIPX
+#if AF_IPX
     /* Look for IPX addresses with all framing types */
     fd = get_socket_for_af(AF_IPX);
     if (fd >= 0) {
@@ -547,7 +547,7 @@ int if_fetch(struct interface *ife)
     }
 #endif
 
-#if HAVE_AFECONET
+#if AF_ECONET
     /* Econet address maybe? */
     fd = get_socket_for_af(AF_ECONET);
     if (fd >= 0) {
@@ -681,16 +681,16 @@ void ife_print_long(struct interface *ptr)
     char *Rext, *Text;
     static char flags[200];
 
-#if HAVE_AFIPX
+#if AF_IPX
     static const struct aftype *ipxtype = NULL;
 #endif
-#if HAVE_AFECONET
+#if AF_ECONET
     static const struct aftype *ectype = NULL;
 #endif
-#if HAVE_AFATALK
+#if AF_APPLETALK
     static const struct aftype *ddptype = NULL;
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
     FILE *f;
     char addr6[40], devname[21];
     struct sockaddr_storage sas;
@@ -766,7 +766,7 @@ void ife_print_long(struct interface *ptr)
 
 
 
-#if HAVE_AFINET
+#if AF_INET
     if (ptr->has_ip) {
 	printf(_("        %s %s"), ap->name,
 	       ap->sprint(&ptr->addr_sas, 1));
@@ -781,7 +781,7 @@ void ife_print_long(struct interface *ptr)
     }
 #endif
 
-#if HAVE_AFINET6
+#if AF_INET6
     /* FIXME: should be integrated into interface.c.   */
 
     if ((f = fopen(_PATH_PROCNET_IFINET6, "r")) != NULL) {
@@ -824,7 +824,7 @@ void ife_print_long(struct interface *ptr)
     }
 #endif
 
-#if HAVE_AFIPX
+#if AF_IPX
     if (ipxtype == NULL)
 	ipxtype = get_afntype(AF_IPX);
 
@@ -844,7 +844,7 @@ void ife_print_long(struct interface *ptr)
     }
 #endif
 
-#if HAVE_AFATALK
+#if AF_APPLETALK
     if (ddptype == NULL)
 	ddptype = get_afntype(AF_APPLETALK);
     if (ddptype != NULL) {
@@ -853,7 +853,7 @@ void ife_print_long(struct interface *ptr)
     }
 #endif
 
-#if HAVE_AFECONET
+#if AF_ECONET
     if (ectype == NULL)
 	ectype = get_afntype(AF_ECONET);
     if (ectype != NULL) {

--- a/lib/ipx.c
+++ b/lib/ipx.c
@@ -15,10 +15,10 @@
  */
 #include "config.h"
 
-#if HAVE_AFIPX
+#include <sys/socket.h>
+#if AF_IPX
 #include <asm/types.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1)
 #include <netipx/ipx.h>
 #else

--- a/lib/ipx_gr.c
+++ b/lib/ipx_gr.c
@@ -7,10 +7,10 @@
 
 #include "config.h"
 
-#if HAVE_AFIPX
+#include <sys/socket.h>
+#if AF_IPX
 #include <asm/types.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1)
 #include <netipx/ipx.h>
 #else
@@ -90,4 +90,4 @@ int IPX_rprint(int options)
     return (0);
 }
 
-#endif				/* HAVE_AFIPX */
+#endif				/* AF_IPX */

--- a/lib/ipx_sr.c
+++ b/lib/ipx_sr.c
@@ -10,10 +10,10 @@
 
 #include "config.h"
 
-#if HAVE_AFIPX
+#include <sys/socket.h>
+#if AF_IPX
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -43,4 +43,4 @@ int IPX_rinput(int action, int ext, char **args)
     fprintf(stderr, _("IPX: this needs to be written\n"));
     return (E_NOSUPP);
 }
-#endif				/* HAVE_AFIPX */
+#endif				/* AF_IPX */

--- a/lib/net-features.h
+++ b/lib/net-features.h
@@ -126,61 +126,61 @@ static char *Features =
 "(" DFLT_AF ")"
 #endif
 
-#if HAVE_AFUNIX
+#if AF_UNIX
 " +"
 #else
 " -"
 #endif
 "UNIX "
-#if HAVE_AFINET
+#if AF_INET
 "+"
 #else
 "-"
 #endif
 "INET "
-#if HAVE_AFINET6
+#if AF_INET6
 "+"
 #else
 "-"
 #endif
 "INET6 "
-#if HAVE_AFIPX
+#if AF_IPX
 "+"
 #else
 "-"
 #endif
 "IPX "
-#if HAVE_AFAX25
+#if AF_AX25
 "+"
 #else
 "-"
 #endif
 "AX25 "
-#if HAVE_AFNETROM
+#if AF_NETROM
 "+"
 #else
 "-"
 #endif
 "NETROM "
-#if HAVE_AFX25
+#if AF_X25
 "+"
 #else
 "-"
 #endif
 "X25 "
-#if HAVE_AFATALK
+#if AF_APPLETALK
 "+"
 #else
 "-"
 #endif
 "ATALK "
-#if HAVE_AFECONET
+#if AF_ECONET
 "+"
 #else
 "-"
 #endif
 "ECONET "
-#if HAVE_AFROSE
+#if AF_ROSE
 "+"
 #else
 "-"

--- a/lib/net-support.h
+++ b/lib/net-support.h
@@ -240,7 +240,7 @@ extern char afname[256];
 /* this is a 2.0.36 flag from /usr/src/linux/include/linux/route.h */
 #define RTF_NOTCACHED   0x0400          /* this route isn't cached        */
 
-#if HAVE_AFECONET
+#if AF_ECONET
 #ifndef AF_ECONET
 #define AF_ECONET       19      /* Acorn Econet */
 #endif

--- a/lib/netrom.c
+++ b/lib/netrom.c
@@ -25,7 +25,7 @@
  */
 #include "config.h"
 
-#if HAVE_AFNETROM || HAVE_HWNETROM
+#if AF_NETROM || HAVE_HWNETROM
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
@@ -206,4 +206,4 @@ struct aftype netrom_aftype =
     "/proc/net/nr"
 };
 
-#endif				/* HAVE_AFNETROM */
+#endif				/* AF_NETROM */

--- a/lib/netrom_gr.c
+++ b/lib/netrom_gr.c
@@ -20,7 +20,8 @@
  */
 #include "config.h"
 
-#if HAVE_AFNETROM
+#include <sys/socket.h>
+#if AF_NETROM
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -76,4 +77,4 @@ int NETROM_rprint(int options)
     return 0;
 }
 
-#endif				/* HAVE_AFNETROM */
+#endif				/* AF_NETROM */

--- a/lib/netrom_sr.c
+++ b/lib/netrom_sr.c
@@ -10,10 +10,10 @@
 
 #include "config.h"
 
-#if HAVE_AFNETROM
+#include <sys/socket.h>
+#if AF_NETROM
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -53,4 +53,4 @@ int NETROM_rinput(int action, int ext, char **args)
     fprintf(stderr, _("NET/ROM: this needs to be written\n"));
     return (E_NOSUPP);
 }
-#endif				/* HAVE_AFNETROM */
+#endif				/* AF_NETROM */

--- a/lib/rose.c
+++ b/lib/rose.c
@@ -17,7 +17,7 @@
  */
 #include "config.h"
 
-#if HAVE_AFROSE || HAVE_HWROSE
+#if AF_ROSE || HAVE_HWROSE
 #include <features.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>

--- a/lib/rose_gr.c
+++ b/lib/rose_gr.c
@@ -22,12 +22,12 @@
  */
 #include "config.h"
 
-#if HAVE_AFROSE
+#include <sys/socket.h>
+#if AF_ROSE
 #if 0
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <linux/rose.h>
-#include <sys/socket.h>
 #include <net/if_arp.h>		/* ARPHRD_ROSE */
 #include <ctype.h>
 #include <errno.h>
@@ -89,4 +89,4 @@ int ROSE_rprint(int options)
     return 0;
 }
 
-#endif				/* HAVE_AFROSE */
+#endif				/* AF_ROSE */

--- a/lib/setroute.c
+++ b/lib/setroute.c
@@ -44,26 +44,26 @@ extern struct aftype x25_aftype;
 
 void setroute_init(void)
 {
-#if HAVE_AFINET
+#if AF_INET
     inet_aftype.rinput = INET_rinput;
 #endif
-#if HAVE_AFINET6
+#if AF_INET6
     inet6_aftype.rinput = INET6_rinput;
 #endif
-#if HAVE_AFNETROM
+#if AF_NETROM
     netrom_aftype.rinput = NETROM_rinput;
 #endif
-#if HAVE_AFIPX
+#if AF_IPX
     ipx_aftype.rinput = IPX_rinput;
 #endif
-#if HAVE_AFX25
+#if AF_X25
     x25_aftype.rinput = X25_rinput;
 #endif
 #if 0
-#if HAVE_AFAX25
+#if AF_AX25
     ax25_aftype.rinput = AX25_rinput;
 #endif
-#if HAVE_AFATALK
+#if AF_APPLETALK
     ddp_aftype.rinput = DDP_rinput;
 #endif
 #endif

--- a/lib/sockets.c
+++ b/lib/sockets.c
@@ -47,11 +47,11 @@ int sockets_open(int family)
 	    if (access(af->flag_file, R_OK))
 		continue;
 	}
-#if HAVE_AFNETROM
+#if AF_NETROM
 	if (af->af == AF_NETROM)
 	    type = SOCK_SEQPACKET;
 #endif
-#if HAVE_AFX25
+#if AF_X25
        if (af->af == AF_X25)
            type = SOCK_SEQPACKET;
 #endif

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -16,7 +16,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#if HAVE_AFUNIX
+#if AF_UNIX
 #include <sys/un.h>
 #endif
 #include <stdlib.h>
@@ -59,7 +59,7 @@ static const char *UNSPEC_sprint(const struct sockaddr_storage *sasp, int numeri
 }
 
 
-#if HAVE_AFUNIX
+#if AF_UNIX
 
 /* Display a UNIX domain address. */
 static const char *UNIX_print(const char *ptr)
@@ -88,7 +88,7 @@ struct aftype unix_aftype =
     -1,
     "/proc/net/unix"
 };
-#endif				/* HAVE_AFUNIX */
+#endif				/* AF_UNIX */
 
 
 struct aftype unspec_aftype =

--- a/lib/x25.c
+++ b/lib/x25.c
@@ -17,7 +17,7 @@
  */
 #include "config.h"
 
-#if HAVE_AFX25 || HAVE_HWX25
+#if AF_X25 || HAVE_HWX25
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>

--- a/lib/x25_gr.c
+++ b/lib/x25_gr.c
@@ -18,11 +18,11 @@
  */
 #include "config.h"
 
-#if HAVE_AFX25
+#include <sys/socket.h>
+#if AF_X25
 #if 0
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <linux/x25.h>
 #include <linux/if_arp.h>	/* ARPHRD_X25 */
 #include <ctype.h>
@@ -96,4 +96,4 @@ int X25_rprint(int options)
 	return 0;
 }
 
-#endif	/* HAVE_AFX25 */
+#endif	/* AF_X25 */

--- a/lib/x25_sr.c
+++ b/lib/x25_sr.c
@@ -13,11 +13,11 @@
  */
 #include "config.h"
 
-#if HAVE_AFX25
+#include <sys/socket.h>
+#if AF_X25
 #include <asm/types.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <linux/x25.h>
 #include <ctype.h>
@@ -148,4 +148,4 @@ int X25_rinput(int action, int options, char **args)
 
   return(X25_setroute(action, options, args));
 }
-#endif	/* HAVE_AFX25 */
+#endif	/* AF_X25 */

--- a/netstat.c
+++ b/netstat.c
@@ -191,7 +191,7 @@ FILE *procinfo;
     fclose(procinfo);					\
   }
 
-#if HAVE_AFINET6
+#if AF_INET6
 #define INFO_GUTS2(file,proc,prot)			\
   lnr = 0;						\
   procinfo = proc_fopen((file));		       	\
@@ -501,7 +501,7 @@ static void prg_cache_load(void)
 			 " will not be shown, you would have to be root to see it all.)\n"));
 }
 
-#if HAVE_AFNETROM
+#if AF_NETROM
 static const char *netrom_state[] =
 {
     N_("LISTENING"),
@@ -555,7 +555,7 @@ static int netrom_info(void)
 }
 #endif
 
-#if HAVE_AFROSE
+#if AF_ROSE
 static const char * const rose_state[] =
 {
     N_("LISTENING"),
@@ -619,7 +619,7 @@ enum {
     TCP_CLOSING			/* now a valid state */
 };
 
-#if HAVE_AFINET || HAVE_AFINET6
+#if AF_INET || AF_INET6
 
 static const char *tcp_state[] =
 {
@@ -663,7 +663,7 @@ static void igmp_do_one(int lnr, const char *line,const char *prot)
     char mcast_addr[128];
     struct sockaddr_storage sas;
     struct sockaddr_in *sin = (struct sockaddr_in *)&sas;
-#if HAVE_AFINET6
+#if AF_INET6
     char addr6[INET6_ADDRSTRLEN];
     struct in6_addr in6;
     extern struct aftype inet6_aftype;
@@ -693,7 +693,7 @@ static void igmp_do_one(int lnr, const char *line,const char *prot)
     }
 
     if (igmp6_flag) {    /* IPV6 */
-#if HAVE_AFINET6
+#if AF_INET6
 	num = sscanf( line, "%d %15s %64[0-9A-Fa-f] %d", &idx, device, mcast_addr, &refcnt );
 	if (num == 4) {
 	    /* Demangle what the kernel gives us */
@@ -722,7 +722,7 @@ static void igmp_do_one(int lnr, const char *line,const char *prot)
 	printf("%-15s %-6d %s\n", device, refcnt, mcast_addr);
 #endif
     } else {    /* IPV4 */
-#if HAVE_AFINET
+#if AF_INET
 	if (line[0] != '\t') {
 	    if (idx_flag) {
 		if ((num = sscanf(line, "%d\t%15c", &idx, device)) < 2) {
@@ -765,7 +765,7 @@ static void igmp_do_one(int lnr, const char *line,const char *prot)
     }    /* IPV4 */
 }
 
-#if HAVE_AFX25
+#if AF_X25
 static int x25_info(void)
 {
        FILE *f=proc_fopen(_PATH_PROCNET_X25);
@@ -837,7 +837,7 @@ static const char *sctp_socket_state_str(int state)
 static const struct aftype *process_sctp_addr_str(const char *addr_str, struct sockaddr_storage *sas)
 {
     if (strchr(addr_str,':')) {
-#if HAVE_AFINET6
+#if AF_INET6
 	extern struct aftype inet6_aftype;
 	/* Demangle what the kernel gives us */
 	struct in6_addr in6;
@@ -1122,7 +1122,7 @@ static void tcp_do_one(int lnr, const char *line, const char *prot)
     struct sockaddr_storage localsas, remsas;
     struct sockaddr_in *localaddr = (struct sockaddr_in *)&localsas;
     struct sockaddr_in *remaddr = (struct sockaddr_in *)&remsas;
-#if HAVE_AFINET6
+#if AF_INET6
     char addr6[INET6_ADDRSTRLEN];
     struct in6_addr in6;
     extern struct aftype inet6_aftype;
@@ -1146,7 +1146,7 @@ static void tcp_do_one(int lnr, const char *line, const char *prot)
       return;
 
     if (strlen(local_addr) > 8) {
-#if HAVE_AFINET6
+#if AF_INET6
 	/* Demangle what the kernel gives us */
 	sscanf(local_addr, "%08X%08X%08X%08X",
 	       &in6.s6_addr32[0], &in6.s6_addr32[1],
@@ -1226,7 +1226,7 @@ static int notnull(const struct sockaddr_storage *sas)
 {
     const struct sockaddr_in *sin = (const struct sockaddr_in *)sas;
 
-#if HAVE_AFINET6
+#if AF_INET6
     const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sas;
 
     if (sin6->sin6_family == AF_INET6) {
@@ -1248,7 +1248,7 @@ static void udp_do_one(int lnr, const char *line,const char *prot)
     struct sockaddr_storage localsas, remsas;
     struct sockaddr_in *localaddr = (struct sockaddr_in *)&localsas;
     struct sockaddr_in *remaddr = (struct sockaddr_in *)&remsas;
-#if HAVE_AFINET6
+#if AF_INET6
     char addr6[INET6_ADDRSTRLEN];
     struct in6_addr in6;
     extern struct aftype inet6_aftype;
@@ -1271,7 +1271,7 @@ static void udp_do_one(int lnr, const char *line,const char *prot)
     }
 
     if (strlen(local_addr) > 8) {
-#if HAVE_AFINET6
+#if AF_INET6
 	sscanf(local_addr, "%08X%08X%08X%08X",
 	       &in6.s6_addr32[0], &in6.s6_addr32[1],
 	       &in6.s6_addr32[2], &in6.s6_addr32[3]);
@@ -1362,7 +1362,7 @@ static void raw_do_one(int lnr, const char *line,const char *prot)
     struct sockaddr_storage localsas, remsas;
     struct sockaddr_in *localaddr = (struct sockaddr_in *)&localsas;
     struct sockaddr_in *remaddr = (struct sockaddr_in *)&remsas;
-#if HAVE_AFINET6
+#if AF_INET6
     char addr6[INET6_ADDRSTRLEN];
     struct in6_addr in6;
     extern struct aftype inet6_aftype;
@@ -1384,7 +1384,7 @@ static void raw_do_one(int lnr, const char *line,const char *prot)
     }
 
     if (strlen(local_addr) > 8) {
-#if HAVE_AFINET6
+#if AF_INET6
 	sscanf(local_addr, "%08X%08X%08X%08X",
 	       &in6.s6_addr32[0], &in6.s6_addr32[1],
            &in6.s6_addr32[2], &in6.s6_addr32[3]);
@@ -1450,7 +1450,7 @@ static int raw_info(void)
 #endif
 
 
-#if HAVE_AFUNIX
+#if AF_UNIX
 
 #define HAS_INODE 1
 
@@ -1604,7 +1604,7 @@ static int unix_info(void)
 #endif
 
 
-#if HAVE_AFAX25
+#if AF_AX25
 static int ax25_info(void)
 {
     FILE *f;
@@ -1699,7 +1699,7 @@ static int ax25_info(void)
 #endif
 
 
-#if HAVE_AFIPX
+#if AF_IPX
 static int ipx_info(void)
 {
     FILE *f;
@@ -2225,7 +2225,7 @@ int main
 	+ flag_l2cap + flag_rfcomm;
 
     if (flag_mas) {
-#if HAVE_FW_MASQUERADE && HAVE_AFINET
+#if HAVE_FW_MASQUERADE && AF_INET
 #if MORE_THAN_ONE_MASQ_AF
 	if (!afname[0])
         safe_strncpy(afname, DFLT_AF, sizeof(afname));
@@ -2249,14 +2249,14 @@ int main
             safe_strncpy(afname, DFLT_AF, sizeof(afname));
 
         if (!strcmp(afname, "inet")) {
-#if HAVE_AFINET
+#if AF_INET
             parsesnmp(flag_raw, flag_tcp, flag_udp, flag_sctp);
 #else
             ENOSUPP("netstat", "AF INET");
             exit(1);
 #endif
         } else if(!strcmp(afname, "inet6")) {
-#if HAVE_AFINET6
+#if AF_INET6
             parsesnmp6(flag_raw, flag_tcp, flag_udp);
 #else
             ENOSUPP("netstat", "AF INET6");
@@ -2303,7 +2303,7 @@ int main
     }
     for (;;) {
 	if (!flag_arg || flag_tcp || flag_sctp || flag_udp || flag_udplite || flag_raw) {
-#if HAVE_AFINET
+#if AF_INET
 	    prg_cache_load();
 	    printf(_("Active Internet connections "));	/* xxx */
 
@@ -2330,7 +2330,7 @@ int main
 	    }
 #endif
 	}
-#if HAVE_AFINET
+#if AF_INET
 	if (!flag_arg || flag_tcp) {
 	    i = tcp_info();
 	    if (i)
@@ -2362,7 +2362,7 @@ int main
 	}
 
 	if (flag_igmp) {
-#if HAVE_AFINET6
+#if AF_INET6
 	    printf( "IPv6/");
 #endif
 	    printf( _("IPv4 Group Memberships\n") );
@@ -2375,7 +2375,7 @@ int main
 #endif
 
 	if (!flag_arg || flag_unx) {
-#if HAVE_AFUNIX
+#if AF_UNIX
 	    prg_cache_load();
 	    i = unix_info();
 	    if (i)
@@ -2388,7 +2388,7 @@ int main
 #endif
 	}
 	if (!flag_arg || flag_ipx) {
-#if HAVE_AFIPX
+#if AF_IPX
 	    i = ipx_info();
 	    if (i)
 		return (i);
@@ -2400,7 +2400,7 @@ int main
 #endif
 	}
 	if (!flag_arg || flag_ax25) {
-#if HAVE_AFAX25
+#if AF_AX25
 	    i = ax25_info();
 	    if (i)
 		return (i);
@@ -2412,7 +2412,7 @@ int main
 #endif
 	}
 	if(!flag_arg || flag_x25) {
-#if HAVE_AFX25
+#if AF_X25
 	    /* FIXME */
 	    i = x25_info();
 	    if (i)
@@ -2425,7 +2425,7 @@ int main
 #endif
 	}
 	if (!flag_arg || flag_netrom) {
-#if HAVE_AFNETROM
+#if AF_NETROM
 	    i = netrom_info();
 	    if (i)
 		return (i);
@@ -2437,7 +2437,7 @@ int main
 #endif
 	}
 	if (!flag_arg || flag_rose) {
-#if HAVE_AFROSE
+#if AF_ROSE
           i = rose_info();
           if (i)
             return (i);


### PR DESCRIPTION
AF_UNIX <- HAVE_AFUNIX.
AF_INET <- HAVE_AFINET.
AF_INET6 <- HAVE_AFINET6.
AF_IPX <- HAVE_AFIPX.
AF_APPLETALK <- HAVE_AFATALK.
AF_NETROM <- HAVE_AFNETROM.
AF_AX25 <- HAVE_AFAX25.
AF_ROSE <- HAVE_AFROSE.
AF_X25 <- HAVE_AFX25.
AF_ECONET <- HAVE_AFECONET.
AF_ASH <- HAVE_AFASH.