### PR TITLE
slattach: Support tty speeds 230400 to 4000000.

### DIFF
--- a/slattach.c
+++ b/slattach.c
@@ -95,6 +95,45 @@ struct {
 #ifdef B115200
   { "115200",	B115200	},
 #endif
+#ifdef B230400
+  { "230400",	B230400	},
+#endif
+#ifdef B460800
+  { "460800",	B460800	},
+#endif
+#ifdef B500000
+  { "500000",	B500000	},
+#endif
+#ifdef B576000
+  { "576000",	B576000	},
+#endif
+#ifdef B921600
+  { "921600",	B921600	},
+#endif
+#ifdef B1000000
+  { "1000000",	B1000000 },
+#endif
+#ifdef B1152000
+  { "1152000",	B1152000 },
+#endif
+#ifdef B1500000
+  { "1500000",	B1500000 },
+#endif
+#ifdef B2000000
+  { "2000000",	B2000000 },
+#endif
+#ifdef B2500000
+  { "2500000",	B2500000 },
+#endif
+#ifdef B3000000
+  { "3000000",	B3000000 },
+#endif
+#ifdef B3500000
+  { "3500000",	B3500000 },
+#endif
+#ifdef B4000000
+  { "4000000",	B4000000 },
+#endif
   { NULL,	0	}
 };
 struct termios	tty_saved,		/* saved TTY device state	*/


### PR DESCRIPTION
I am using SLIP with `slattach` to communicate with an FPGA.  It would be nice if `slattach` would allow to directly set also the higher speeds.  (4 Mbps even works for my communication.)