### PR TITLE
clean RTM_HOST flag for ipv6 route

### DIFF
--- a/lib/inet6_sr.c
+++ b/lib/inet6_sr.c
@@ -93,8 +93,6 @@ static int INET6_setroute(int action, int options, char **args)
 
     /* Fill in the other fields. */
     rt.rtmsg_flags = RTF_UP;
-    if (prefix_len == 128)
-	rt.rtmsg_flags |= RTF_HOST;
     rt.rtmsg_metric = 1;
     rt.rtmsg_dst_len = prefix_len;
 


### PR DESCRIPTION
Keep action same with ip command

Before the patch:
$ip -6 route add 2409:8080:5a0a:60c7::7/128 via 2409:8080:5a0a:60c7::7 dev eth2
$ip -6 route add 2409:8080:5a0a:60c7::8/128 via 2409:8080:5a0a:60c7::7 dev eth2
RTNETLINK answers: No route to host
$ route -A inet6 add 2409:8080:5a0a:60c7::8/128 gw 2409:8080:5a0a:60c7::7 dev eth2
$
After the patch:
$route -A inet6 add 2409:8080:5a0a:60c7::8/128 gw 2409:8080:5a0a:60c7::7 dev eth2
SIOCADDRT: No route to host

fixes #27 
