### PR TITLE
fix typos in netstat man (de_DE)

### DIFF
--- a/man/de_DE/netstat.8
+++ b/man/de_DE/netstat.8
@@ -236,12 +236,12 @@ Eine Verbindungsanfrage wurde von der Gegenseite empfangen.
 .TP
 .I
 FIN_WAIT1
-Der Socket wurde geschlo\(ssen und die Verbindung wird beendet.
+Der Socket wurde geschlossen und die Verbindung wird beendet.
 .TP
 .I
 FIN_WAIT2
-Die Verbindung ist geschl\(ssen und der Socket wartet darauf, da\(ss sie
-von der Gegenseite ebenfalls geschlo\(ssen wird.
+Die Verbindung ist geschlossen und der Socket wartet darauf, dass sie
+von der Gegenseite ebenfalls geschlossen wird.
 .TP
 .I
 TIME_WAIT
@@ -259,7 +259,7 @@ wird erwartet.
 .TP
 .I
 LAST_ACK
-Die Gegenseite hat die Verbindung beendet und der Socket ist geschlo\(ssen;
+Die Gegenseite hat die Verbindung beendet und der Socket ist geschlossen;
 die Best\(:atigung wird abgewartet.
 .TP
 .I
@@ -271,7 +271,7 @@ Option gew\(:ahlt wird.
 .TP
 .I
 CLOSING
-Beide Sockets sind geschlo\(ssen, es wurden aber noch nicht alle Daten
+Beide Sockets sind geschlossen, es wurden aber noch nicht alle Daten
 geschickt.
 .TP
 .I
@@ -291,7 +291,7 @@ Privilegien ben\(:otigt um die n\(:otigen Daten zu erhalten.  F\(:ur IPX
 Sockets sind diese Daten nicht verf\(:ugbar.
 
 .SS "Timer"
-(dies mu\(ss noch geschrieben werden)
+(dies muss noch geschrieben werden)
 
 .PP
 .SS aktive Sockets in der UNIX Dom\(:ane
@@ -331,7 +331,7 @@ Der Socket wird als RAW-Socket verwendet.
 .TP
 .I
 SOCK_RDM
-Dieser Socket bedient zuverl\(ssig zugestellte Nachrichten.
+Dieser Socket bedient zuverl\(:assig zugestellte Nachrichten.
 .TP
 .I
 SOCK_SEQPACKET
@@ -344,7 +344,7 @@ Socket mit direktem (RAW) Zugriff auf die Schnittstelle.
 .TP
 .I
 UNKNOWN
-Wer wei\(ss, was uns die Zukunft bringt soll es hier hinschreiben :-)
+Wer wei\(ss, was uns die Zukunft bringt, soll es hier hinschreiben :-)
 
 .PP
 .SS "Zustand"


### PR DESCRIPTION
Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900962

This is part of #32 