### PR TITLE
statistics: Add CSUM metrics for UDP and sync UDPv4/v6 metrics.

### DIFF
--- a/statistics.c
+++ b/statistics.c
@@ -203,6 +203,8 @@ static const struct entry Udp6tab[] =
     {"Udp6InErrors", N_("%llu packet receive errors"), number},
     {"Udp6NoPorts", N_("%llu packets to unknown port received"), number},
     {"Udp6OutDatagrams", N_("%llu packets sent"), number},
+    {"Udp6RcvbufErrors", N_("%llu receive buffer errors"), number},
+    {"Udp6SndbufErrors", N_("%llu send buffer errors"), number},
 };
 
 static const struct entry Tcpexttab[] =

--- a/statistics.c
+++ b/statistics.c
@@ -187,6 +187,7 @@ static const struct entry Tcptab[] =
 
 static const struct entry Udptab[] =
 {   /* Keep the entries sorted! */
+    {"InCsumErrors", N_("%llu packets with invalid checksum"), number},
     {"InDatagrams", N_("%llu packets received"), number},
     {"InErrors", N_("%llu packet receive errors"), number},
     {"NoPorts", N_("%llu packets to unknown port received"), number},
@@ -197,6 +198,7 @@ static const struct entry Udptab[] =
 
 static const struct entry Udp6tab[] =
 {   /* Keep the entries sorted! */
+    {"Udp6InCsumErrors", N_("%llu packets with invalid checksum"), number},
     {"Udp6InDatagrams", N_("%llu packets received"), number},
     {"Udp6InErrors", N_("%llu packet receive errors"), number},
     {"Udp6NoPorts", N_("%llu packets to unknown port received"), number},


### PR DESCRIPTION
The first commit adds the checksum error metric, and the 2nd patch adds recvbuf/sendbuf metrics for UDPv6 that are already supported by UDPv4.