### PR TITLE
ifconfig: Change interface name length overflow to warning.

### DIFF
--- a/ifconfig.c
+++ b/ifconfig.c
@@ -332,10 +332,7 @@ int main(int argc, char **argv)
     spp = argv;
     size_t len = strlen(*spp);
     if (len >= IFNAMSIZ)
-    {
-	fprintf(stderr, "%s(%lu): interface name length must be < %i\n", *spp, len, IFNAMSIZ);
-	return EXIT_FAILURE;
-    }
+	fprintf(stderr, _("Warning: truncating interface name %s length %lu to %u\n"), *spp, len, IFNAMSIZ-1);
     safe_strncpy(ifr.ifr_name, *spp++, IFNAMSIZ);
     if (*spp == (char *) NULL) {
 	int err = if_print(ifr.ifr_name);


### PR DESCRIPTION
Interface name is limited to IFNAMSIZ. To keep compatibility with the old behavior before 7a8f42f, change the error to warning.