### PR TITLE
Revert 55c95c0

### DIFF
--- a/lib/interface.c
+++ b/lib/interface.c
@@ -173,6 +173,8 @@ static int if_readconf(void)
        (as of 2.1.128) */
     skfd = get_socket_for_af(AF_INET);
     if (skfd < 0) {
+	fprintf(stderr, _("warning: no inet socket available: %s\n"),
+		strerror(errno));
 	/* Try to soldier on with whatever socket we can get hold of.  */
 	skfd = sockets_open(0);
 	if (skfd < 0)


### PR DESCRIPTION
The patch addressed a specific net-tools-1.60 problem: attempt to access a socket before it is actually opened. This does not happen in recent versions, so the patch is more harmful than useful, as it could hide a real problem, if it happens.

For more see
https://github.com/ecki/net-tools/issues/32#issuecomment-3265471116