### PR TITLE
man: netstat: add two examples

### DIFF
--- a/man/en_US/netstat.8
+++ b/man/en_US/netstat.8
@@ -545,6 +545,22 @@ which gives access to kernel status information via the following files.
 .I /proc/net/snmp
 -- statistics
 
+.SH EXAMPLES
+List all open TCP and UDP ports, with the corresponding process's PID. This lets you answer "which process is listening on port 8080?":
+.RS
+.nf
+\fBnetstat -tulpn\fR
+.fi
+.RE
+
+.P
+Show the route table (it's often best to pass -n to display IP addresses rather than hostnames):
+.RS
+.nf
+\fBnetstat -rn\fR
+.fi
+.RE
+
 .SH BUGS
 Occasionally strange information may appear if a socket changes
 as it is viewed. This is unlikely to occur.


### PR DESCRIPTION
I'm a long-time netstat user, but it took me a while to figure out what combination of flags would be useful to pass to netstat. I only ended up learning about "-tulpn" because a friend told me how they used netstat.

This adds a couple of examples of common ways to use netstat, so that future beginners can potentially learn about common patterns to use the tool from the man page instead of having to know someone, and so that infrequent users can use it as a quick reminder.

I also asked on Mastodon to do a little crowdsourcing of [popular netstat options](https://social.jvns.ca/@b0rk/116122152984403761). I settled on -tulpn since it seems like a fairly common favourite.